### PR TITLE
Monotonix 依存関係機能のテスト用設定を追加

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -25,21 +25,21 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@add-claude-to-gitignore
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request_target' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@add-claude-to-gitignore
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@add-claude-to-gitignore
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@add-claude-to-gitignore
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -61,7 +61,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@add-claude-to-gitignore
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,17 +21,17 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@add-claude-to-gitignore
         with:
           root-dir: apps
           required-config-keys: 'go_test'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@add-claude-to-gitignore
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@add-claude-to-gitignore
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -52,7 +52,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@28250d732ee703a83ba217401e1b575969e8967b # v0.0.2
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@add-claude-to-gitignore
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+
+# Go binaries
+apps/echo/echo
+apps/hello-world/hello-world

--- a/apps/echo/go.mod
+++ b/apps/echo/go.mod
@@ -1,3 +1,7 @@
 module github.com/yuya-takeyama/monotonix-playgound/apps/echo
 
-go 1.23.4
+go 1.24.4
+
+require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0
+
+replace github.com/yuya-takeyama/monotonix-playground/apps/pkg/common => ../pkg/common

--- a/apps/echo/main.go
+++ b/apps/echo/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/yuya-takeyama/monotonix-playground/apps/pkg/common"
 )
 
 func echoHandler(w http.ResponseWriter, r *http.Request) {
@@ -23,10 +25,12 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Update
 func main() {
 	http.HandleFunc("/", echoHandler)
-	log.Println("Starting echo server on :8080")
+	startupMsg := common.GetTimestampedMessage("ECHO", "Starting echo server on :8080")
+	versionMsg := common.GetTimestampedMessage("ECHO", fmt.Sprintf("Using common library version: %s", common.GetVersion()))
+	log.Println(startupMsg)
+	log.Println(versionMsg)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		log.Fatal(err)
 	}

--- a/apps/echo/monotonix.yaml
+++ b/apps/echo/monotonix.yaml
@@ -1,5 +1,7 @@
 app:
   name: echo
+  depends_on:
+    - pkg/common
 jobs:
   build_prd:
     on:

--- a/apps/hello-world/go.mod
+++ b/apps/hello-world/go.mod
@@ -1,3 +1,7 @@
 module github.com/yuya-takeyama/monotonix-playgound/apps/hello-world
 
-go 1.23.4
+go 1.24.4
+
+require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0
+
+replace github.com/yuya-takeyama/monotonix-playground/apps/pkg/common => ../pkg/common

--- a/apps/hello-world/main.go
+++ b/apps/hello-world/main.go
@@ -4,16 +4,20 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/yuya-takeyama/monotonix-playground/apps/pkg/common"
 )
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Hello, World!")
 }
 
-// Update 26
 func main() {
 	http.HandleFunc("/", helloHandler)
-	log.Println("Starting server on :8080")
+	startupMsg := common.GetTimestampedMessage("HELLO-WORLD", "Starting server on :8080")
+	versionMsg := common.GetTimestampedMessage("HELLO-WORLD", fmt.Sprintf("Using common library version: %s", common.GetVersion()))
+	log.Println(startupMsg)
+	log.Println(versionMsg)
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		log.Fatal(err)
 	}

--- a/apps/hello-world/monotonix.yaml
+++ b/apps/hello-world/monotonix.yaml
@@ -1,5 +1,7 @@
 app:
   name: hello-world
+  depends_on:
+    - pkg/common
 jobs:
   build_prd:
     on:

--- a/apps/pkg/common/go.mod
+++ b/apps/pkg/common/go.mod
@@ -1,0 +1,3 @@
+module github.com/yuya-takeyama/monotonix-playground/apps/pkg/common
+
+go 1.24.4

--- a/apps/pkg/common/message.go
+++ b/apps/pkg/common/message.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"fmt"
+	"time"
+)
+
+// GetTimestampedMessage returns a message with the current timestamp
+func GetTimestampedMessage(prefix string, message string) string {
+	return fmt.Sprintf("[%s] %s: %s", time.Now().Format(time.RFC3339), prefix, message)
+}
+
+// GetVersion returns the common library version
+func GetVersion() string {
+	return "v1.0.0"
+}

--- a/apps/pkg/common/message_test.go
+++ b/apps/pkg/common/message_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetTimestampedMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		message  string
+		contains []string
+	}{
+		{
+			name:     "basic message",
+			prefix:   "INFO",
+			message:  "Hello World",
+			contains: []string{"INFO", "Hello World", "["},
+		},
+		{
+			name:     "empty prefix",
+			prefix:   "",
+			message:  "Test message",
+			contains: []string{": Test message"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetTimestampedMessage(tt.prefix, tt.message)
+			for _, substr := range tt.contains {
+				if !strings.Contains(result, substr) {
+					t.Errorf("GetTimestampedMessage() = %v, want substring %v", result, substr)
+				}
+			}
+		})
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	expected := "v1.0.0"
+	if got := GetVersion(); got != expected {
+		t.Errorf("GetVersion() = %v, want %v", got, expected)
+	}
+}

--- a/apps/pkg/common/monotonix.yaml
+++ b/apps/pkg/common/monotonix.yaml
@@ -1,0 +1,11 @@
+app:
+  name: common
+jobs:
+  go_test:
+    on:
+      pull_request:
+      push:
+        branches:
+          - main
+    configs:
+      go_test:


### PR DESCRIPTION
## 概要
Monotonix の新しい依存関係機能（PR #97）をテストするための設定を追加しました。

- `apps/pkg/common` パッケージを作成し、共通ユーティリティ関数とテストを追加
- `echo` と `hello-world` アプリを `pkg/common` に依存するように設定
- `depends_on` フィールドを使用して Monotonix の依存関係を設定
- GitHub Actions で新しい Monotonix ブランチを使用するように更新

## 変更内容
- **pkg/common パッケージ**:
  - タイムスタンプ付きメッセージ機能
  - バージョン取得機能
  - Go テストファイル
  - Monotonix 設定ファイル
- **echo/hello-world アプリ**:
  - pkg/common への依存関係を追加
  - 起動時に共通ライブラリのメッセージ・バージョンを表示
  - monotonix.yaml に `depends_on` フィールドを追加
- **GitHub Actions**:
  - Monotonix のバージョンを PR ブランチ（`add-claude-to-gitignore`）に更新

## テスト計画
- [ ] pkg/common パッケージを変更すると echo と hello-world の CI/CD が自動でトリガーされることを確認
- [ ] 依存関係の変更伝播が正常に動作することを確認
- [ ] Go テストが全てのパッケージで実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)