### PR TITLE
Docker ビルドエラーの修正と GitHub Actions の改善

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -54,6 +54,7 @@ jobs:
       id-token: write
       actions: read
     strategy:
+      fail-fast: false
       matrix:
         job: ${{ fromJSON(needs.setup.outputs.jobs) }}
     steps:

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -45,6 +45,7 @@ jobs:
       contents: read
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         job: ${{ fromJSON(needs.setup.outputs.jobs) }}
     steps:

--- a/apps/echo/go.mod
+++ b/apps/echo/go.mod
@@ -2,6 +2,4 @@ module github.com/yuya-takeyama/monotonix-playgound/apps/echo
 
 go 1.24.4
 
-require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0
-
-replace github.com/yuya-takeyama/monotonix-playground/apps/pkg/common => ../pkg/common
+require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427

--- a/apps/echo/go.sum
+++ b/apps/echo/go.sum
@@ -1,0 +1,2 @@
+github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427 h1:Jx6oKi08qltVyLLNtlVkn+CcbCOXodQ9LHkydkbjcaE=
+github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427/go.mod h1:2y45jZ0oBd58jvVe+kbDgfsBlXExzxpb7LRWN8cJ00A=

--- a/apps/hello-world/go.mod
+++ b/apps/hello-world/go.mod
@@ -2,6 +2,4 @@ module github.com/yuya-takeyama/monotonix-playgound/apps/hello-world
 
 go 1.24.4
 
-require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0
-
-replace github.com/yuya-takeyama/monotonix-playground/apps/pkg/common => ../pkg/common
+require github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427

--- a/apps/hello-world/go.sum
+++ b/apps/hello-world/go.sum
@@ -1,0 +1,2 @@
+github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427 h1:Jx6oKi08qltVyLLNtlVkn+CcbCOXodQ9LHkydkbjcaE=
+github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427/go.mod h1:2y45jZ0oBd58jvVe+kbDgfsBlXExzxpb7LRWN8cJ00A=


### PR DESCRIPTION
## 概要
Docker ビルド時に発生していたローカル依存関係エラーを修正し、GitHub Actions のワークフローを改善しました。

## 修正内容
### Docker ビルドエラーの解決
- **問題**: ローカルパスの `replace` 文により Docker ビルドが失敗
  ```
  go: github.com/yuya-takeyama/monotonix-playground/apps/pkg/common@v0.0.0 (replaced by ../pkg/common): reading /pkg/common/go.mod: open /pkg/common/go.mod: no such file or directory
  ```
- **解決策**: commit SHA ベースのバージョニングに変更
  - `apps/echo/go.mod` と `apps/hello-world/go.mod` から `replace` 文を削除
  - GitHub からの直接参照に変更: `v0.0.0-20250713041617-841204e80427`

### GitHub Actions の改善
- **全ての matrix strategy に `fail-fast: false` を追加**
  - `go-test.yaml` と `build-docker.yaml` の両方に適用
  - 1つのジョブが失敗しても他のジョブが継続実行される
  - デバッグ時の可視性が向上

## 動作確認
- ✅ ローカルでの `go mod tidy` と `go build` が成功
- ✅ 依存関係が GitHub から正常に解決される
- ✅ Docker ビルドエラーの原因を除去

## テスト計画
- [x] Docker ビルドが正常に完了することを確認
- [ ] matrix ジョブで一部が失敗しても他が継続されることを確認
- [ ] pkg/common への依存関係が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)