### PR TITLE
test: dependency-based job triggering feature

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -25,21 +25,23 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@yuya-takeyama/feat/app-dependencies
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request_target' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@add-depends-on
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@yuya-takeyama/feat/app-dependencies
+        with:
+          root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@yuya-takeyama/feat/app-dependencies
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@yuya-takeyama/feat/app-dependencies
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -62,7 +64,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@yuya-takeyama/feat/app-dependencies
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/apps/foo/test-file.txt
+++ b/apps/foo/test-file.txt
@@ -3,4 +3,3 @@ This is a test file to trigger workflow changes detection.
 Created for testing Monotonix workflow file change detection functionality.
 Timestamp: 2025-07-13
 Update
-Update

--- a/apps/foo/test-file.txt
+++ b/apps/foo/test-file.txt
@@ -3,3 +3,5 @@ This is a test file to trigger workflow changes detection.
 Created for testing Monotonix workflow file change detection functionality.
 Timestamp: 2025-07-13
 Update
+
+🚀 Testing dependency feature - should trigger api-server and worker builds!

--- a/apps/hello-world/monotonix.yaml
+++ b/apps/hello-world/monotonix.yaml
@@ -1,7 +1,7 @@
 app:
   name: hello-world
   depends_on:
-    - pkg/common
+    - foo/pkg/common
 jobs:
   build_prd:
     on:


### PR DESCRIPTION
## 🚀 依存関係機能のテスト

fooアプリに変更を加えて、依存する子アプリのジョブが自動実行されるかテストします。

## 変更内容

-  にテスト用のコンテンツを追加

## 期待される動作

この変更により以下のジョブが **自動的にトリガー** されるはずです：

### ✅ 実行されるべきジョブ
-  の各ビルドジョブ (depends_on: ["foo"])
-  の各ビルドジョブ (depends_on: ["foo"])  
-  の各ジョブ (depends_on: ["foo/pkg/common"])

### ❌ 実行されないジョブ
-  アプリ (依存関係なし)

## テスト観点

1. **直接変更検知**: fooアプリ自体の変更が検知される
2. **依存関係伝播**: fooに依存するapi-serverとworkerのジョブが実行される
3. **過度な実行防止**: 関係ないechoアプリは実行されない

## 技術詳細

- Monotonix actions:  ブランチ使用
- 依存関係解決: timestamp + dependency propagation
- フィルタリング: changed files + dependency graph