### PR TITLE
Monotonix アクション参照を main ブランチに更新

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -25,23 +25,23 @@ jobs:
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@yuya-takeyama/feat/app-dependencies
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request_target' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@yuya-takeyama/feat/app-dependencies
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
         with:
           root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@yuya-takeyama/feat/app-dependencies
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@yuya-takeyama/feat/app-dependencies
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@main
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -64,7 +64,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@yuya-takeyama/feat/app-dependencies
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,17 +21,19 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
         with:
           root-dir: apps
           required-config-keys: 'go_test'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@add-depends-on
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
+        with:
+          root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -53,7 +55,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@add-depends-on
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/apps/web-app/pkg/update.txt
+++ b/apps/web-app/pkg/update.txt
@@ -1,0 +1,3 @@
+Updated at 2025-01-13 by Yuya
+Testing Monotonix branch reference updates
+Random test content for file changes


### PR DESCRIPTION
## 概要
- GitHub Actions ワークフローで使用している Monotonix アクションの参照を全て main ブランチに更新
- テスト用ファイル `apps/web-app/pkg/update.txt` を追加
- `go-test.yaml` で不足していた `root-dir` パラメータを追加

## 変更内容
- `.github/workflows/build-docker.yaml`: 5つのアクション参照を main ブランチに変更
- `.github/workflows/go-test.yaml`: 4つのアクション参照を main ブランチに変更、`filter-jobs-by-changed-files` に `root-dir` パラメータを追加
- `apps/web-app/pkg/update.txt`: 新規ファイル追加（テスト用）

## テスト計画
- [ ] CI が正常に動作すること
- [ ] Monotonix のジョブが正しく実行されること

🤖 Generated with [Claude Code](https://claude.ai/code)