### PR TITLE
build-docker workflow の pull_request_target を pull_request に変更

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     paths:
       - .github/workflows/build-docker.yaml
       - apps/**
@@ -29,7 +29,7 @@ jobs:
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
-      - if: ${{ github.event_name == 'pull_request_target' }}
+      - if: ${{ github.event_name == 'pull_request' }}
         uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
         with:
           root-dir: apps

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -9,9 +9,6 @@ on:
       - .github/workflows/build-docker.yaml
       - apps/**
 
-env:
-  CHECKOUT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -23,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
       - uses: yuya-takeyama/monotonix/actions/load-jobs@main
         with:
@@ -70,8 +66,6 @@ jobs:
           dynamodb-region: ap-northeast-1
           job: ${{ toJSON(matrix.job) }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ env.CHECKOUT_REF }}
 
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:

--- a/apps/hello-world/monotonix.yaml
+++ b/apps/hello-world/monotonix.yaml
@@ -33,7 +33,7 @@ jobs:
           - linux/amd64
   build_dev_pr:
     on:
-      pull_request_target:
+      pull_request:
     configs:
       docker_build:
         registry:

--- a/apps/web-app/cmd/api-server/monotonix.yaml
+++ b/apps/web-app/cmd/api-server/monotonix.yaml
@@ -41,7 +41,7 @@ jobs:
         go_version_file: apps/web-app/go.mod
   build_dev_pr:
     on:
-      pull_request_target:
+      pull_request:
     configs:
       docker_build:
         registry:

--- a/apps/web-app/cmd/worker/monotonix.yaml
+++ b/apps/web-app/cmd/worker/monotonix.yaml
@@ -41,7 +41,7 @@ jobs:
         go_version_file: apps/web-app/go.mod
   build_dev_pr:
     on:
-      pull_request_target:
+      pull_request:
     configs:
       docker_build:
         registry:

--- a/apps/web-app/pkg/update.txt
+++ b/apps/web-app/pkg/update.txt
@@ -1,1 +1,1 @@
-Update
+Update - Testing PR trigger with pull_request event


### PR DESCRIPTION
## 概要
build-docker.yaml ワークフローで使用されている `pull_request_target` イベントを `pull_request` イベントに変更し、`CHECKOUT_REF` 環境変数を削除しました。

## 変更内容
1. **イベントタイプの変更**
   - `pull_request_target:` → `pull_request:`
   - `github.event_name == 'pull_request_target'` → `github.event_name == 'pull_request'`

2. **CHECKOUT_REF の削除**
   - `env` セクションの `CHECKOUT_REF` 定義を削除
   - checkout アクションから `ref: ${{ env.CHECKOUT_REF }}` を削除
   - go-test.yaml と同様のデフォルト動作（マージコミットのチェックアウト）を使用するように変更

## 背景
- `pull_request_target` は主にフォークからのPRで権限が必要な処理（secretsへのアクセスなど）を実行する際に使用されますが、セキュリティリスクもあるため、必要がない限り通常の `pull_request` イベントを使用することが推奨されています
- `CHECKOUT_REF` を削除することで、go-test.yaml と同じシンプルな構成になり、保守性が向上します

## テスト方法
このPRがマージされた後、新しいPRを作成してbuild-dockerワークフローが正常に動作することを確認してください。