### PR TITLE
setup-go のキャッシュ警告を修正

### DIFF
--- a/apps/hello-world/go.sum
+++ b/apps/hello-world/go.sum
@@ -1,2 +1,0 @@
-github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427 h1:Jx6oKi08qltVyLLNtlVkn+CcbCOXodQ9LHkydkbjcaE=
-github.com/yuya-takeyama/monotonix-playground/apps/pkg/common v0.0.0-20250713041617-841204e80427/go.mod h1:2y45jZ0oBd58jvVe+kbDgfsBlXExzxpb7LRWN8cJ00A=

--- a/apps/web-app/cmd/api-server/monotonix.yaml
+++ b/apps/web-app/cmd/api-server/monotonix.yaml
@@ -22,6 +22,7 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum
   build_dev_main:
     on:
       push:
@@ -39,6 +40,7 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum
   build_dev_pr:
     on:
       pull_request:
@@ -54,3 +56,4 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum

--- a/apps/web-app/cmd/worker/monotonix.yaml
+++ b/apps/web-app/cmd/worker/monotonix.yaml
@@ -22,6 +22,7 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum
   build_dev_main:
     on:
       push:
@@ -39,6 +40,7 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum
   build_dev_pr:
     on:
       pull_request:
@@ -54,3 +56,4 @@ jobs:
           - linux/amd64
       docker_build_go_build:
         go_version_file: apps/web-app/go.mod
+        cache_dependency_path: apps/web-app/go.sum


### PR DESCRIPTION
## 概要
GitHub Actions で発生していた setup-go のキャッシュ警告を修正します。

## 問題
以下の警告が発生していました：
```
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/monotonix-playground/monotonix-playground. Supported file pattern: go.sum
```

## 修正内容
1. **cache_dependency_path の追加**
   - `web-app/cmd/api-server/monotonix.yaml` に `cache_dependency_path: apps/web-app/go.sum` を追加
   - `web-app/cmd/worker/monotonix.yaml` に `cache_dependency_path: apps/web-app/go.sum` を追加

2. **不要な依存関係の削除**
   - `hello-world/go.sum` から実際には使用していない `pkg/common` への依存を削除

## テスト方法
- [ ] PR でビルドが正常に動作し、キャッシュ警告が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)