### PR TITLE
Monotonix Actions を v0.0.3 にアップデート

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -21,23 +21,23 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@v0.0.3
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -60,7 +60,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -21,23 +21,23 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@v0.0.3
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@v0.0.3
         with:
           root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@main
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@v0.0.3
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -60,7 +60,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1 # v0.0.32
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@cefe963a6b4ae0e511c59b9d6cb6b7b5923714a1 # v0.0.32
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,19 +21,19 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           root-dir: apps
           required-config-keys: 'go_test'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@v0.0.3
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -55,7 +55,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,19 +21,19 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@v0.0.3
         with:
           root-dir: apps
           required-config-keys: 'go_test'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@v0.0.3
         with:
           root-dir: apps
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -55,7 +55,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@v0.0.3
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/apps/hello-world/main.go
+++ b/apps/hello-world/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "Hello, World!")
+	fmt.Fprintln(w, "Hello, World! (Built with Monotonix v0.0.3)")
 }
 
 func main() {

--- a/apps/web-app/pkg/update.txt
+++ b/apps/web-app/pkg/update.txt
@@ -1,1 +1,1 @@
-Update 2
+Update 3 - Testing monotonix v0.0.3

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -31,6 +31,36 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_darwin_amd64.tar.gz",
+      "checksum": "A8DF4AF42EC777E63E7A3812D8CC7107C037BDAAA225DEF679444F87B5EE1905",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_darwin_arm64.tar.gz",
+      "checksum": "0C89C8492F05C6CE27ED16D3B66C1811452B1961BDEEA27EDD6D318163374884",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_linux_amd64.tar.gz",
+      "checksum": "20D6B69172A9B59D18C8295817F0FF0FC306EE36CD7D39378B2DD34F1CD75C4E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_linux_arm64.tar.gz",
+      "checksum": "E4FECE6E63CC757E734FEAC99826026813451C7D988836BC29C0507D114C1F18",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_windows_amd64.zip",
+      "checksum": "2DE33F4B28C41590A52E329F08E6415AFE7ED98671AD3D99A7CDEC92D3D42771",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v3.3.0/pinact_windows_arm64.zip",
+      "checksum": "6D9C862B1C152F696DD3EC948435C1379E18225573F26773CD9A4A62A6842B36",
+      "algorithm": "sha256"
+    },
+    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.386.0/registry.yaml",
       "checksum": "297DCBFBAC90D85B1C44F1C0E1EC9622A666B2FAEF5979BB553A761A28AA3E87C631E83E623B77EBF64B18D864DEDC7B90D7E646146AA91CBCE59509A0447386",
       "algorithm": "sha512"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
 # aqua - Declarative CLI Version Manager
 # https://aquaproj.github.io/
 checksum:
@@ -11,3 +12,4 @@ registries:
     ref: v4.386.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: cli/cli@v2.75.0
+  - name: suzuki-shunsuke/pinact@v3.3.0


### PR DESCRIPTION
## Summary
- Monotonix の全 Actions を @main から @v0.0.3 にアップデート
- build-docker.yaml と go-test.yaml の両方で更新

## Test plan
- [ ] CI が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)