### PR TITLE
test: migrate to simplify-action-parameters

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -21,23 +21,22 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@yuya-takeyama/feat/simplify-action-parameters
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
-        with:
-          root-dir: apps
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@yuya-takeyama/feat/simplify-action-parameters
+        # root-dir parameter removed
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@yuya-takeyama/feat/simplify-action-parameters
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@yuya-takeyama/feat/simplify-action-parameters
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -60,7 +59,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@yuya-takeyama/feat/simplify-action-parameters
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,19 +21,18 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@yuya-takeyama/feat/simplify-action-parameters
         with:
           root-dir: apps
           required-config-keys: 'go_test'
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
-        with:
-          root-dir: apps
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@yuya-takeyama/feat/simplify-action-parameters
+        # root-dir parameter removed
       - uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@yuya-takeyama/feat/simplify-action-parameters
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -55,7 +54,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@d353007a9b7a33a360fae79e5b558daded5aade2 # v0.0.3
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@yuya-takeyama/feat/simplify-action-parameters
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/apps/hello-world/monotonix.yaml
+++ b/apps/hello-world/monotonix.yaml
@@ -1,5 +1,3 @@
-app:
-  name: hello-world
 jobs:
   build_prd:
     on:

--- a/apps/web-app/cmd/api-server/monotonix.yaml
+++ b/apps/web-app/cmd/api-server/monotonix.yaml
@@ -1,9 +1,8 @@
 app:
-  name: web-app/cmd/api-server
   depends_on:
-    - web-app/pkg
-    - web-app/go.mod
-    - web-app/go.sum
+    - apps/web-app/pkg
+    - apps/web-app/go.mod
+    - apps/web-app/go.sum
 jobs:
   build_prd:
     on:

--- a/apps/web-app/cmd/worker/monotonix.yaml
+++ b/apps/web-app/cmd/worker/monotonix.yaml
@@ -1,9 +1,8 @@
 app:
-  name: web-app/cmd/worker
   depends_on:
-    - web-app/pkg
-    - web-app/go.mod
-    - web-app/go.sum
+    - apps/web-app/pkg
+    - apps/web-app/go.mod
+    - apps/web-app/go.sum
 jobs:
   build_prd:
     on:

--- a/apps/web-app/monotonix.yaml
+++ b/apps/web-app/monotonix.yaml
@@ -1,5 +1,3 @@
-app:
-  name: web-app
 jobs:
   go_test:
     on:


### PR DESCRIPTION
## Summary

- Migrate to yuya-takeyama/monotonix#133 branch to test breaking changes
- Test the simplified action parameters and configuration

## Changes

### Workflow Updates
- All monotonix actions now use `yuya-takeyama/feat/simplify-action-parameters` branch
- Removed `root-dir` parameter from `filter-jobs-by-changed-files` action

### Configuration Migration
- **app.name removal**: Removed from all `monotonix.yaml` files (now auto-generated from path)
- **app field simplification**: Completely removed `app` field where no dependencies exist
- **depends_on path updates**: Updated to include `apps/` prefix for consistency

### Breaking Changes Tested
1. ✅ Auto app label generation (from app_path + root_dir)
2. ✅ Root-dir parameter removal (context-based sharing)
3. ✅ App field optional (省略可能)
4. ✅ Depends_on path format (root-dir included)

## Verification Points

- [ ] hello-world builds correctly (no dependencies, app field omitted)
- [ ] web-app components build correctly (with updated dependency paths)
- [ ] Changed file detection works without explicit root-dir parameter
- [ ] App labels are generated correctly without app.name

🧪 This is a test migration for monotonix breaking changes validation.