### PR TITLE
feat: Switch to Monotonix main branch with metadata support

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -21,22 +21,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
           global-config-file-path: apps/monotonix-global.yaml
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@main
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -59,7 +59,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -21,21 +21,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
         with:
           root-dir: apps
           required-config-keys: 'docker_build'
+          global-config-file-path: apps/monotonix-global.yaml
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/load-docker-build-job-params@main
         with:
           global-config-file-path: apps/monotonix-global.yaml
           timezone: Asia/Tokyo
@@ -58,7 +59,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,17 +21,18 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
         with:
           root-dir: apps
           required-config-keys: 'go_test'
+          global-config-file-path: apps/monotonix-global.yaml
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -53,7 +54,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -21,18 +21,18 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: yuya-takeyama/monotonix/actions/load-jobs@main
+      - uses: yuya-takeyama/monotonix/actions/load-jobs@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           root-dir: apps
           required-config-keys: 'go_test'
           global-config-file-path: apps/monotonix-global.yaml
       - if: ${{ github.event_name == 'pull_request' }}
-        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@main
+        uses: yuya-takeyama/monotonix/actions/filter-jobs-by-changed-files@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@main
+      - uses: yuya-takeyama/monotonix/actions/filter-jobs-by-dynamodb-state@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1
@@ -54,7 +54,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::920373013500:role/monotonix-state-manager
           aws-region: ap-northeast-1
-      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@main
+      - uses: yuya-takeyama/monotonix/actions/set-dynamodb-state-to-running@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4
         with:
           dynamodb-table: monotonix-state
           dynamodb-region: ap-northeast-1


### PR DESCRIPTION
## Summary

Switches Monotonix action references from v0.0.4 to the main branch which now includes the merged metadata support feature (former PR #151).

## Changes

- Updated all Monotonix action references from `@1ee58090547501c1b691407d21db1dee9374de7e # v0.0.4` to `@main`
- Added `global-config-file-path: apps/monotonix-global.yaml` parameter to `load-jobs` actions
- This enables JSON Schema validation for app and job metadata

## Testing

The metadata validation feature was successfully tested in PR #75 where it correctly:
- Detected valid metadata (✅ passed validation)
- Caught invalid metadata (❌ failed with detailed error messages)
- Provided debug logs showing the validation process

Now using the production-ready metadata support that was merged into Monotonix main.

---
Co-Authored-By: Claude <noreply@anthropic.com>