### PR TITLE
Remove docker_build_go_build in favor of multi-stage Dockerfile builds

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -74,27 +74,10 @@ jobs:
         with:
           registry-type: ${{ matrix.job.params.docker_build.registry.aws.repository.type }}
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      # Go Build
-      - if: ${{ matrix.job.configs.docker_build_go_build }}
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version-file: ${{ matrix.job.configs.docker_build_go_build.go_version_file }}
-          cache-dependency-path: ${{ matrix.job.configs.docker_build_go_build.cache_dependency_path }}
-      - if: ${{ matrix.job.configs.docker_build_go_build }}
-        name: Run Go Build for docker build
-        run: |
-          cd "$APP_PATH"
-          go build -o main
-        env:
-          APP_PATH: ${{ matrix.job.params.docker_build.context }}
-          CGO_ENABLED: '0'
-          GOOS: linux
-          GOARCH: amd64
-
       - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ matrix.job.params.docker_build.context }}
+          file: ${{ matrix.job.params.docker_build.dockerfile }}
           push: true
           tags: ${{ matrix.job.params.docker_build.tags }}
           platforms: ${{ matrix.job.params.docker_build.platforms }}

--- a/apps/web-app/cmd/api-server/Dockerfile
+++ b/apps/web-app/cmd/api-server/Dockerfile
@@ -1,6 +1,15 @@
+FROM golang:1.25.6 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main ./cmd/api-server
+
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY main /
+COPY --from=builder /app/main /
 
 EXPOSE 8080
 

--- a/apps/web-app/cmd/api-server/monotonix.yaml
+++ b/apps/web-app/cmd/api-server/monotonix.yaml
@@ -22,6 +22,8 @@ jobs:
           - main
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -30,9 +32,6 @@ jobs:
         tagging: semver_datetime
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum
   build_dev_main:
     metadata:
       priority: medium
@@ -44,6 +43,8 @@ jobs:
           - main
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -52,9 +53,6 @@ jobs:
         tagging: always_latest
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum
   build_dev_pr:
     metadata:
       priority: high
@@ -64,6 +62,8 @@ jobs:
       pull_request:
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -72,6 +72,3 @@ jobs:
         tagging: pull_request
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum

--- a/apps/web-app/cmd/worker/Dockerfile
+++ b/apps/web-app/cmd/worker/Dockerfile
@@ -1,5 +1,14 @@
+FROM golang:1.25.6 AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main ./cmd/worker
+
 FROM gcr.io/distroless/static-debian12:nonroot
 
-COPY main /
+COPY --from=builder /app/main /
 
 CMD ["/main"]

--- a/apps/web-app/cmd/worker/monotonix.yaml
+++ b/apps/web-app/cmd/worker/monotonix.yaml
@@ -22,6 +22,8 @@ jobs:
           - main
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -30,9 +32,6 @@ jobs:
         tagging: semver_datetime
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum
   build_dev_main:
     metadata:
       priority: medium
@@ -44,6 +43,8 @@ jobs:
           - main
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -52,9 +53,6 @@ jobs:
         tagging: always_latest
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum
   build_dev_pr:
     metadata:
       priority: medium
@@ -64,6 +62,8 @@ jobs:
       pull_request:
     configs:
       docker_build:
+        context: ../..
+        dockerfile: Dockerfile
         registry:
           type: aws
           aws:
@@ -72,6 +72,3 @@ jobs:
         tagging: pull_request
         platforms:
           - linux/amd64
-      docker_build_go_build:
-        go_version_file: apps/web-app/go.mod
-        cache_dependency_path: apps/web-app/go.sum


### PR DESCRIPTION
## Summary
- Remove `docker_build_go_build` configuration from the repository
- Migrate api-server and worker to use multi-stage Dockerfile builds
- Utilize the new `context` and `dockerfile` options in monotonix.yaml

## Changes
- **Dockerfiles**: Updated `api-server` and `worker` Dockerfiles to include a builder stage that compiles Go binaries
- **monotonix.yaml**: Added `context: ../..` and `dockerfile: Dockerfile` to docker_build configs, removed `docker_build_go_build` configs
- **build-docker.yaml**: Removed Go build steps and added `file` parameter to docker/build-push-action

## Test plan
- [ ] Verify CI builds complete successfully
- [ ] Confirm Docker images are pushed to ECR correctly

---
Generated with Claude's assistance